### PR TITLE
fix: corrige referências incorretas ao org 'allfluence'

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ AI-powered web search and content extraction.
 
 ## Documentation
 
-For detailed documentation, visit [AIOS Core Discussions](https://github.com/allfluence/aios-core/discussions).
+For detailed documentation, visit [AIOS Core Discussions](https://github.com/SynkraAI/aios-core/discussions).
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](https://github.com/allfluence/aios-core/blob/main/CONTRIBUTING.md).
+We welcome contributions! Please see our [Contributing Guide](https://github.com/SynkraAI/aios-core/blob/main/CONTRIBUTING.md).
 
 ## License
 
@@ -92,4 +92,4 @@ Apache 2.0 License - see [LICENSE](./LICENSE)
 
 ---
 
-Part of the [AIOS Framework](https://github.com/allfluence/aios-core)
+Part of the [AIOS Framework](https://github.com/SynkraAI/aios-core)

--- a/ide-configs/claude/sample-config.json
+++ b/ide-configs/claude/sample-config.json
@@ -17,6 +17,6 @@
   "notes": {
     "description": "Sample Claude Code configuration for AIOS projects",
     "preset": "aios-dev",
-    "documentation": "https://github.com/allfluence/mcp-ecosystem"
+    "documentation": "https://github.com/SynkraAI/mcp-ecosystem"
   }
 }

--- a/ide-configs/cursor/sample-config.json
+++ b/ide-configs/cursor/sample-config.json
@@ -12,6 +12,6 @@
   "notes": {
     "description": "Sample Cursor configuration for AIOS projects",
     "preset": "aios-dev",
-    "documentation": "https://github.com/allfluence/mcp-ecosystem"
+    "documentation": "https://github.com/SynkraAI/mcp-ecosystem"
   }
 }


### PR DESCRIPTION
## Resumo

- Substitui todas as referências de `allfluence` por `SynkraAI` no README e configs de IDE
- Os links de documentação, contribuição e referência do framework estavam apontando para organização inexistente

## Arquivos alterados

| Arquivo | Alteração |
|---------|-----------|
| `README.md` | 3 URLs corrigidas (discussions, CONTRIBUTING, aios-core) |
| `ide-configs/claude/sample-config.json` | URL de documentação corrigida |
| `ide-configs/cursor/sample-config.json` | URL de documentação corrigida |

## Verificação

Todas as 5 ocorrências de `allfluence` foram substituídas por `SynkraAI`:
```
github.com/SynkraAI/aios-core/discussions
github.com/SynkraAI/aios-core/blob/main/CONTRIBUTING.md
github.com/SynkraAI/aios-core
github.com/SynkraAI/mcp-ecosystem (×2)
```

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation and configuration URL references to reflect organizational changes across project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->