### PR TITLE
fix: adiciona servidores MCP faltantes nos configs de IDE

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "pt-BR"
+tone_instructions: "Seja profissional, construtivo e foque em qualidade de código. Escreva em português."
+early_access: false
+
+reviews:
+  auto_review:
+    enabled: true
+    base_branches: [main, master]
+    drafts: false
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  path_instructions:
+    - path: "**/*.json"
+      instructions: |
+        Validar JSON: sem trailing commas, chaves entre aspas.
+        Configs MCP: verificar `mcpServers`, `command`, `args` estão bem formados.
+        Sem secrets/API keys em valores literais — usar env vars.
+    - path: "**/Dockerfile*"
+      instructions: |
+        Multi-stage quando aplicável. Imagens base com tag pinned (sem :latest).
+        Sem segredos no build; usar build args ou secrets do Docker.
+        USER não-root quando possível.
+    - path: "**/*.yml"
+      instructions: |
+        YAML: validar indentação. Sem secrets hardcoded.
+        docker-compose: versão fixa, volumes mapeados conscientemente.
+    - path: ".github/**"
+      instructions: Segurança, secrets, sintaxe.
+
+chat:
+  auto_reply: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Copilot Instructions — mcp-ecosystem
+
+## Project Overview
+Repositório de configuração e orquestração de servidores MCP (Model Context Protocol), com Docker/Compose.
+
+## Stack
+- **Docker** + **docker-compose** para containers MCP
+- Configs em **JSON** (mcp servers config)
+- **YAML** para compose e workflows
+
+## Conventions
+- JSON válido sem trailing commas; chaves entre aspas
+- Configs MCP com `mcpServers`, `command`, `args` bem formados
+- Sem secrets em valores literais — env vars
+- Dockerfiles: imagens base com tag pinned (sem `:latest`)
+- docker-compose: versão fixa, volumes conscientes
+- YAML: indentação 2 espaços, sem tabs
+
+## Folder Structure
+- `configs/` ou raiz — JSONs de configuração MCP
+- `docker/` ou `Dockerfile*` — definições de container
+- `docker-compose.yml` — orquestração
+
+## Development
+- `docker compose up -d` — sobe stack
+- `docker compose logs -f <service>` — logs
+- `docker compose down` — para
+
+## Critical Files
+- `docker-compose.yml` — orquestração principal
+- `configs/*.json` — definições MCP
+- `Dockerfile*` — imagens custom

--- a/ide-configs/claude/sample-config.json
+++ b/ide-configs/claude/sample-config.json
@@ -12,11 +12,18 @@
     "playwright": {
       "command": "npx",
       "args": ["-y", "@anthropic/playwright-mcp"]
+    },
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server"],
+      "env": {
+        "EXA_API_KEY": "${EXA_API_KEY}"
+      }
     }
   },
   "notes": {
     "description": "Sample Claude Code configuration for AIOS projects",
-    "preset": "aios-dev",
-    "documentation": "https://github.com/allfluence/mcp-ecosystem"
+    "preset": "aios-full",
+    "documentation": "https://github.com/SynkraAI/mcp-ecosystem"
   }
 }

--- a/ide-configs/cursor/sample-config.json
+++ b/ide-configs/cursor/sample-config.json
@@ -7,11 +7,22 @@
     "desktop-commander": {
       "command": "npx",
       "args": ["-y", "@anthropic/desktop-commander-mcp"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/playwright-mcp"]
+    },
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server"],
+      "env": {
+        "EXA_API_KEY": "${EXA_API_KEY}"
+      }
     }
   },
   "notes": {
     "description": "Sample Cursor configuration for AIOS projects",
-    "preset": "aios-dev",
-    "documentation": "https://github.com/allfluence/mcp-ecosystem"
+    "preset": "aios-full",
+    "documentation": "https://github.com/SynkraAI/mcp-ecosystem"
   }
 }


### PR DESCRIPTION
## Resumo

- Adiciona `exa` ao config do Claude Code e Cursor
- Adiciona `playwright` ao config do Cursor (já presente no Claude)
- Atualiza preset de referência para `aios-full`
- Corrige URLs da documentação (`allfluence` → `SynkraAI`)

## Problema

Os configs de IDE estavam incompletos em relação aos servidores disponíveis:

| Servidor | Claude Config | Cursor Config |
|----------|:---:|:---:|
| context7 | ✅ → ✅ | ✅ → ✅ |
| desktop-commander | ✅ → ✅ | ✅ → ✅ |
| playwright | ✅ → ✅ | ❌ → ✅ |
| exa | ❌ → ✅ | ❌ → ✅ |

## Verificação

- JSON válido em ambos os arquivos (validado com `python3 -m json.tool`)
- Configs agora refletem todos os 4 servidores do ecossistema
- `env.EXA_API_KEY` usa interpolação `${EXA_API_KEY}` consistente com `servers/exa.json`

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new IDE tool integrations (playwright, exa) for local development/testing.
* **Chores**
  * Updated configuration preset to the latest "aios-full".
  * Added CodeRabbit configuration with automated review and reply settings.
* **Documentation**
  * Updated project documentation reference URL and added Copilot guidance file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/mcp-ecosystem/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->